### PR TITLE
Add methods for suggested actions

### DIFF
--- a/BotSpec.Tests.Unit/BotSpec.Tests.Unit.csproj
+++ b/BotSpec.Tests.Unit/BotSpec.Tests.Unit.csproj
@@ -35,9 +35,8 @@
       <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Connector.DirectLine.3.0.2\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.4\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>

--- a/BotSpec.Tests.Unit/packages.config
+++ b/BotSpec.Tests.Unit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.18.0" targetFramework="net45" />
-  <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.2" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />

--- a/BotSpec/Assertions/Activities/ActivityAssertions.cs
+++ b/BotSpec/Assertions/Activities/ActivityAssertions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BotSpec.Assertions.Attachments;
 using BotSpec.Exceptions;
 using Microsoft.Bot.Connector.DirectLine;
+using BotSpec.Assertions.Cards.CardComponents;
 
 namespace BotSpec.Assertions.Activities
 {
@@ -81,6 +82,12 @@ namespace BotSpec.Assertions.Activities
         public IActivityAttachmentAssertions WithAttachment()
         {
             return new ActivityAttachmentAssertions(_activity);
+        }
+
+        public ICardActionAssertions WithSuggestedActions()
+        {
+            var actions = _activity.SuggestedActions?.Actions;
+            return new CardActionSetAssertions(actions);
         }
 
         public Func<ActivityAssertionFailedException> CreateEx(string testedProperty, string regex)

--- a/BotSpec/Assertions/Activities/ActivitySetAssertions.cs
+++ b/BotSpec/Assertions/Activities/ActivitySetAssertions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BotSpec.Assertions.Attachments;
 using BotSpec.Exceptions;
 using Microsoft.Bot.Connector.DirectLine;
+using BotSpec.Assertions.Cards.CardComponents;
 
 namespace BotSpec.Assertions.Activities
 {
@@ -97,6 +98,12 @@ namespace BotSpec.Assertions.Activities
         public IActivityAttachmentAssertions WithAttachment()
         {
             return new ActivitySetAttachmentAssertions(_messageSet);
+        }
+
+        public ICardActionAssertions WithSuggestedActions()
+        {
+            var actions = _messageSet.Where(message => message.SuggestedActions?.Actions != null).SelectMany(message => message.SuggestedActions.Actions).ToList();
+            return new CardActionSetAssertions(actions);
         }
 
         public Func<ActivityAssertionFailedException> CreateEx(string testedProperty, string regex)

--- a/BotSpec/Assertions/Activities/IActivityAssertions.cs
+++ b/BotSpec/Assertions/Activities/IActivityAssertions.cs
@@ -1,3 +1,4 @@
+using BotSpec.Assertions.Cards.CardComponents;
 using System.Collections.Generic;
 
 namespace BotSpec.Assertions.Activities
@@ -10,5 +11,6 @@ namespace BotSpec.Assertions.Activities
         IActivityAssertions IdMatching(string regex, string groupMatchRegex, out IList<string> matchedGroups);
         IActivityAssertions FromMatching(string regex);
         IActivityAssertions FromMatching(string regex, string groupMatchRegex, out IList<string> matchedGroups);
+        ICardActionAssertions WithSuggestedActions();
     }
 }

--- a/BotSpec/BotSpec.csproj
+++ b/BotSpec/BotSpec.csproj
@@ -27,9 +27,8 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bot.Connector.DirectLine.3.0.2\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Rest.ClientRuntime.2.3.4\lib\net45\Microsoft.Rest.ClientRuntime.dll</HintPath>

--- a/BotSpec/packages.config
+++ b/BotSpec/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0" targetFramework="net45" />
+  <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.2" targetFramework="net45" />
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Fixes #5 

Example usage:
`expect.Activity().TextMatching("Hi! Tell me what your query is about:").WithSuggestedActions()  .TitleMatching("Shopping").TitleMatching("Eating")TitleMatching("Something else");`